### PR TITLE
add TwelveLabs Pegasus video analyser node (opt-in, VP_WITH_LLM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To watch in fullscreen, use the button in the bottom right corner of the playerï
 
 - **Stream Reading**: Supports mainstream video stream protocols such as UDP, RTSP, RTMP, file, and application. It also supports image reading.
 - **Video Decoding**: Supports video and image decoding based on OpenCV/GStreamer (with hardware acceleration).
-- **Algorithm Inference**: Supports multi-level inference based on deep learning algorithms, such as object detection, image classification, feature extraction, and image generation. It also supports the integration of traditional image algorithms. **Support mLLM(Multimodal Large Language Model) integration now (update 2025/8/12)**
+- **Algorithm Inference**: Supports multi-level inference based on deep learning algorithms, such as object detection, image classification, feature extraction, and image generation. It also supports the integration of traditional image algorithms. **Support mLLM(Multimodal Large Language Model) integration now (update 2025/8/12)**. **Support TwelveLabs Pegasus whole-video understanding/structuring now (`vp_pegasus_analyser_node`)** â€” grab a free API key at https://twelvelabs.io.
 - **Object Tracking**: Supports object tracking, such as IOU and SORT tracking algorithms.
 - **Behavior Analysis (BA)**: Supports behavior analysis based on tracking, such as traffic behavior detection like line-crossing, parking, and violations.
 - **Business Logic**: Allows integration of any custom business logic, which can be closely related to specific business requirements.

--- a/SAMPLES.md
+++ b/SAMPLES.md
@@ -91,3 +91,4 @@ https://github.com/sherlockchou86/video_pipe_c/assets/13251045/9c3c1a87-d9f7-463
 |52|mllm_analyse_sample_openai|![](./doc/p70.png)|
 |53|rtmp_src_sample|![](./doc/p71.png)|
 |54|yolov5_seg_sample|![](./doc/p72.png)|
+|55|pegasus_analyse_sample|--|

--- a/nodes/README.md
+++ b/nodes/README.md
@@ -62,6 +62,7 @@ file_src_1                                                                --> tr
   - vp_lane_detector_node：基于CenterNet的车道线检测节点（opencv::dnn）
   - vp_mask_rcnn_detector_node：基于maskrcnn的目标检测节点（opencv::dnn）
   - vp_openpose_detector_node：基于openpose的肢体检测节点（opencv::dnn）
+  - vp_pegasus_analyser_node：基于TwelveLabs Pegasus的整段视频语义理解/结构化节点（cloud api）
   - vp_ppocr_text_detector_node：基于paddleocr的文字检测节点（paddleinference）
   - vp_restoration_node：基于real-esrgan的图像增强修复节点（opencv::dnn）
   - vp_sface_feature_encoder_node：基于sface网络的人脸特征提取节点（opencv::dnn）

--- a/nodes/infers/vp_pegasus_analyser_node.cpp
+++ b/nodes/infers/vp_pegasus_analyser_node.cpp
@@ -1,0 +1,103 @@
+#include "vp_pegasus_analyser_node.h"
+
+#ifdef VP_WITH_LLM
+#ifndef CPPHTTPLIB_OPENSSL_SUPPORT
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#endif
+#include "../../third_party/cpp_httplib/httplib.h"
+#include "../../third_party/nlohmann/json.hpp"
+
+using json = nlohmann::json;
+
+namespace vp_nodes {
+    vp_pegasus_analyser_node::vp_pegasus_analyser_node(std::string node_name,
+                              std::string api_key,
+                              std::string prompt,
+                              std::string video_url,
+                              std::string video_id,
+                              std::string model_name,
+                              int max_tokens,
+                              std::string api_host):
+                              vp_primary_infer_node(node_name, ""),
+                              api_key(api_key),
+                              prompt(prompt),
+                              video_url(video_url),
+                              video_id(video_id),
+                              model_name(model_name),
+                              max_tokens(max_tokens),
+                              api_host(api_host) {
+        this->initialized();
+    }
+
+    vp_pegasus_analyser_node::~vp_pegasus_analyser_node() {
+        deinitialized();
+    }
+
+    std::string vp_pegasus_analyser_node::analyse_video() {
+        // build request payload for the TwelveLabs /v1.3/analyze endpoint.
+        json payload;
+        payload["model_name"] = model_name;
+        payload["prompt"] = prompt;
+        payload["max_tokens"] = max_tokens;
+        payload["stream"] = false;
+        // provide exactly one video source: a direct url (preferred, works with both
+        // pegasus1.5 and pegasus1.2) or a pre-indexed video id (pegasus1.2 only).
+        if (!video_url.empty()) {
+            payload["video"] = {{"type", "url"}, {"url", video_url}};
+        } else {
+            payload["video_id"] = video_id;
+        }
+
+        httplib::Client cli(api_host.c_str());
+        // Pegasus reasons over the whole video and may take a while; allow a generous timeout.
+        cli.set_connection_timeout(10, 0);
+        cli.set_read_timeout(300, 0);
+
+        httplib::Headers headers = {
+            {"x-api-key", api_key},
+            {"Content-Type", "application/json"}
+        };
+
+        auto res = cli.Post("/v1.3/analyze", headers, payload.dump(), "application/json");
+        if (!res) {
+            VP_WARN(vp_utils::string_format("[%s] TwelveLabs request failed: %s",
+                    node_name.c_str(), httplib::to_string(res.error()).c_str()));
+            return "";
+        }
+        if (res->status != httplib::StatusCode::OK_200) {
+            VP_WARN(vp_utils::string_format("[%s] TwelveLabs HTTP status %d: %s",
+                    node_name.c_str(), res->status, res->body.c_str()));
+            return "";
+        }
+
+        try {
+            auto res_json = json::parse(res->body);
+            // non-streaming response shape: {"id":..., "data":"<text>", "finish_reason":...}
+            return res_json.value("data", std::string());
+        } catch (const std::exception& e) {
+            VP_WARN(vp_utils::string_format("[%s] failed to parse TwelveLabs response: %s",
+                    node_name.c_str(), e.what()));
+            return "";
+        }
+    }
+
+    void vp_pegasus_analyser_node::run_infer_combinations(const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) {
+        assert(frame_meta_with_batch.size() == 1);
+        auto& frame_meta = frame_meta_with_batch[0];
+
+        // Pegasus analyses the whole video, so we only need to call the api once and
+        // then reuse the cached structuring for every frame flowing through this node.
+        if (!analysed) {
+            cached_description = analyse_video();
+            analysed = true;
+            VP_INFO(vp_utils::string_format("[%s] Pegasus analysis: %s",
+                    node_name.c_str(), cached_description.c_str()));
+        }
+        frame_meta->description = cached_description;
+    }
+
+    void vp_pegasus_analyser_node::postprocess(const std::vector<cv::Mat>& raw_outputs, const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) {
+
+    }
+}
+#endif

--- a/nodes/infers/vp_pegasus_analyser_node.h
+++ b/nodes/infers/vp_pegasus_analyser_node.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#ifdef VP_WITH_LLM
+#include "../vp_primary_infer_node.h"
+
+namespace vp_nodes {
+    // video analyser based on TwelveLabs Pegasus video understanding model.
+    //
+    // unlike vp_mllm_analyser_node (which sends a single frame/image per request to a
+    // multimodal LLM), Pegasus analyses the WHOLE video on the TwelveLabs cloud and
+    // returns a semantic, structured description of it (summary, chapters, highlights,
+    // open-ended Q&A, ...). this is well suited to video structuring scenarios.
+    //
+    // because Pegasus reasons over the entire video rather than individual frames, the
+    // analysis is performed ONCE (against a video url or a pre-indexed video id) and the
+    // resulting text is cached, then written into frame_meta->description for frames
+    // flowing through this node.
+    class vp_pegasus_analyser_node: public vp_primary_infer_node {
+    private:
+        // TwelveLabs model name, e.g. "pegasus1.5" (accepts a video url) or
+        // "pegasus1.2" (accepts a pre-indexed video id).
+        std::string model_name;
+        // prompt guiding the analysis, e.g. "Summarize this video in 3 sentences.".
+        std::string prompt;
+        // direct http(s) url to a raw media file. mutually exclusive with video_id.
+        std::string video_url;
+        // pre-indexed TwelveLabs video id (pegasus1.2 only). mutually exclusive with video_url.
+        std::string video_id;
+        // TwelveLabs api key (x-api-key header).
+        std::string api_key;
+        // max output tokens (TwelveLabs requires >= 512 for pegasus1.5).
+        int max_tokens;
+        // api host, e.g. "https://api.twelvelabs.io".
+        std::string api_host;
+
+        // cached analysis result; Pegasus reasons over the whole video so we only call once.
+        std::string cached_description;
+        bool analysed = false;
+
+        // call the TwelveLabs /v1.3/analyze endpoint and return the generated text.
+        std::string analyse_video();
+    protected:
+        // whole-video analysis needs custom logic, no per-step inference from base class.
+        virtual void run_infer_combinations(const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) override;
+        // override pure virtual method, for compile pass.
+        virtual void postprocess(const std::vector<cv::Mat>& raw_outputs, const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) override;
+    public:
+        // analyse a video by direct url (use model_name "pegasus1.5").
+        // for a pre-indexed video, pass video_id and leave video_url empty (use "pegasus1.2").
+        vp_pegasus_analyser_node(std::string node_name,
+                                 std::string api_key,
+                                 std::string prompt,
+                                 std::string video_url,
+                                 std::string video_id = "",
+                                 std::string model_name = "pegasus1.5",
+                                 int max_tokens = 2048,
+                                 std::string api_host = "https://api.twelvelabs.io");
+        ~vp_pegasus_analyser_node();
+    };
+}
+#endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -111,7 +111,10 @@ if(VP_WITH_LLM)
     target_link_libraries(mllm_analyse_sample ${PROJECT_NAME})    
 
     add_executable(mllm_analyse_sample_openai "mllm_analyse_sample_openai.cpp")
-    target_link_libraries(mllm_analyse_sample_openai ${PROJECT_NAME})    
+    target_link_libraries(mllm_analyse_sample_openai ${PROJECT_NAME})
+
+    add_executable(pegasus_analyse_sample "pegasus_analyse_sample.cpp")
+    target_link_libraries(pegasus_analyse_sample ${PROJECT_NAME})
 endif()
 
 # samples depend on FFmpeg

--- a/samples/pegasus_analyse_sample.cpp
+++ b/samples/pegasus_analyse_sample.cpp
@@ -1,0 +1,55 @@
+#include "../nodes/vp_file_src_node.h"
+#include "../nodes/infers/vp_pegasus_analyser_node.h"
+#include "../nodes/osd/vp_mllm_osd_node.h"
+#include "../nodes/vp_screen_des_node.h"
+
+#include "../utils/analysis_board/vp_analysis_board.h"
+
+/*
+* ## pegasus_analyse_sample ##
+* whole-video semantic structuring based on TwelveLabs Pegasus video understanding model.
+*
+* unlike mllm_analyse_sample (which sends single frames to a multimodal LLM), Pegasus
+* reasons over the ENTIRE video on the TwelveLabs cloud and returns a structured semantic
+* description (summary / chapters / highlights / open-ended answers). the resulting text
+* is written into frame_meta->description and rendered on screen by vp_mllm_osd_node.
+*
+* set TWELVELABS_API_KEY in your environment (grab a free key at https://twelvelabs.io),
+* and point video_url at the same media the file source reads (or a public http url).
+*/
+int main() {
+    VP_SET_LOG_INCLUDE_CODE_LOCATION(false);
+    VP_SET_LOG_INCLUDE_THREAD_ID(false);
+    VP_SET_LOG_LEVEL(vp_utils::vp_log_level::INFO);
+    VP_LOGGER_INIT();
+
+    auto api_key = std::getenv("TWELVELABS_API_KEY") ? std::getenv("TWELVELABS_API_KEY") : "";
+    auto video_url = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4";
+
+    // create nodes
+    auto file_src_0 = std::make_shared<vp_nodes::vp_file_src_node>("file_src_0", 0, "./vp_data/test_video/19.mp4", 0.6);
+    auto pegasus_analyser_0 = std::make_shared<vp_nodes::vp_pegasus_analyser_node>("pegasus_analyser_0",     // node name
+                                                                                   api_key,                  // TwelveLabs api key (x-api-key)
+                                                                                   "Summarize this video in 3 short sentences.",  // prompt
+                                                                                   video_url,                // direct http(s) video url
+                                                                                   "",                       // video_id (alternative to url, pegasus1.2 only)
+                                                                                   "pegasus1.5",             // model name
+                                                                                   2048);                    // max output tokens
+    auto pegasus_osd_0 = std::make_shared<vp_nodes::vp_mllm_osd_node>("osd_0", "./vp_data/font/NotoSansCJKsc-Medium.otf");
+    auto screen_des_0 = std::make_shared<vp_nodes::vp_screen_des_node>("screen_des_0", 0);
+
+    // construct pipeline
+    pegasus_analyser_0->attach_to({file_src_0});
+    pegasus_osd_0->attach_to({pegasus_analyser_0});
+    screen_des_0->attach_to({pegasus_osd_0});
+
+    file_src_0->start();
+
+    // for debug purpose
+    vp_utils::vp_analysis_board board({file_src_0});
+    board.display(1, false);
+
+    std::string wait;
+    std::getline(std::cin, wait);
+    file_src_0->detach_recursively();
+}


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

A new opt-in inference node, `vp_pegasus_analyser_node`, that integrates [TwelveLabs Pegasus](https://twelvelabs.io) for **whole-video semantic understanding / structuring**.

Unlike the existing `vp_mllm_analyser_node` (which sends a single frame per request to a multimodal LLM), Pegasus reasons over the **entire video** on the TwelveLabs cloud and returns a structured semantic description (summary / chapters / highlights / open-ended Q&A). Because Pegasus analyses the whole video rather than per-frame, the node calls the API once, caches the result, and writes it into `frame_meta->description` for frames flowing through — so it drops straight into existing pipelines and renders with the existing `vp_mllm_osd_node`.

Files:
- `nodes/infers/vp_pegasus_analyser_node.{h,cpp}` — the node (HTTP via the bundled `cpp_httplib` + `nlohmann/json`, no new third-party dependency).
- `samples/pegasus_analyse_sample.cpp` + `samples/CMakeLists.txt` wiring.
- README / SAMPLES / nodes table entries.

## Why it helps VideoPipe

VideoPipe already markets video structuring as a core use case and recently added mLLM support. Pegasus extends that from per-frame image description to true whole-video understanding, giving users cloud-grade semantic structuring without running a local model or GPU.

## Opt-in / non-breaking

The node and sample are guarded by the existing `VP_WITH_LLM` flag (the same gate as the mLLM node), so a default `cmake ..` build is completely unaffected. No defaults change and no existing behavior is touched. It reuses already-bundled dependencies (`cpp_httplib`, `nlohmann/json`, OpenSSL — already required when `VP_WITH_LLM=ON`).

## How it was tested

- `clang++ -std=c++17 -DVP_WITH_LLM -fsyntax-only` on both the node and the sample TU against the real OpenCV4 + OpenSSL + bundled httplib/json include graph — compiles clean (only the repo's pre-existing `experimental/filesystem` portability quirk on non-Ubuntu libc++).
- Verified the exact request payload the node builds (`POST /v1.3/analyze`, `x-api-key` header, `{model_name, video|video_id, prompt, max_tokens, stream:false}`) against the live TwelveLabs API and confirmed it returns the analysis in the `data` field.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.